### PR TITLE
adding cucumber tests negative scenarios

### DIFF
--- a/src/main/java/com/uw/service/TrainingManagementService.java
+++ b/src/main/java/com/uw/service/TrainingManagementService.java
@@ -63,6 +63,10 @@ public class TrainingManagementService {
        * @return a CompletableFuture containing the ResponseEntity
        */
       public CompletableFuture<ResponseEntity<?>> createTraining(TrainingRequestDTO trainingRequest) {
+            if(trainingRequest.getTrainingName() == null || trainingRequest.getTrainerUsername() == null || trainingRequest.getTraineeUsername() == null) {
+                  return CompletableFuture.completedFuture(ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Invalid training request: missing required fields"));
+            }
+
             Optional<Trainee> traineeOpt = Optional.ofNullable(traineeService.findTraineeByUsername(trainingRequest.getTraineeUsername()));
             if (traineeOpt.isEmpty()) {
                   return CompletableFuture.completedFuture(ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorMessages.TRAINEE_NOT_FOUND));

--- a/src/test/java/com/uw/steps/ComponentTestSteps.java
+++ b/src/test/java/com/uw/steps/ComponentTestSteps.java
@@ -112,4 +112,59 @@ public class ComponentTestSteps {
             Training training = repository.findByTrainingName( trainingRequest.getTrainingName() );
             assertNull(training);
       }
+
+      @Given("an invalid training request with missing or incorrect fields")
+      public void anInvalidTrainingRequestWithMissingOrIncorrectFields() {
+            trainingRequest = new TrainingRequestDTO();
+            trainingRequest.setTrainingName(null); // Missing training name
+            trainingRequest.setTrainingDate(LocalDate.of(2024, 1, 15));
+            trainingRequest.setTraineeUsername(null); // Missing trainee username
+            trainingRequest.setTrainerUsername("jane_smith");
+      }
+
+      @Then("the system returns a 400 Bad Request error")
+      public void theSystemReturnsABadRequestError() {
+            assertEquals(400, response.getStatusCode().value());
+      }
+
+      @Then("an error message is displayed indicating which fields are invalid")
+      public void anErrorMessageIsDisplayedIndicatingInvalidFields() {
+            assertTrue(response.getBody().toString().contains("Invalid training request"));
+      }
+
+      @Given("a training request with a trainer ID that does not exist")
+      public void aTrainingRequestWithNonExistentTrainerID() {
+            trainingRequest = new TrainingRequestDTO();
+            trainingRequest.setTrainingName("Advanced Java");
+            trainingRequest.setTrainingDate(LocalDate.of(2024, 1, 15));
+            trainingRequest.setTraineeUsername("john_doe");
+            trainingRequest.setTrainerUsername("non_existent_trainer");
+      }
+
+      @Then("the system returns a 404 Not Found error")
+      public void theSystemReturnsANotFoundError() {
+            assertEquals(404, response.getStatusCode().value());
+      }
+
+      @Then("an error message is displayed indicating that the trainer was not found")
+      public void anErrorMessageIsDisplayedForNonExistentTrainer() {
+            assertTrue(response.getBody().toString().contains("not found"));
+      }
+
+      @Given("a training session ID that does not exist")
+      public void aNonExistentTrainingSessionID() {
+            // Assuming ID 9999 does not exist
+            trainingRequest = new TrainingRequestDTO();
+      }
+
+      @When("the request is sent to the delete endpoint for a non-existent training session")
+      public void theRequestIsSentToTheDeleteEndpointForNonExistentSession() {
+            response = trainingManagementService.deleteTraining(9999L).join();
+      }
+
+      @Then("an error message is displayed indicating that the session was not found")
+      public void anErrorMessageIsDisplayedForNonExistentSession() {
+            assertTrue(response.getBody().toString().contains("Training not found"));
+      }
+
 }

--- a/src/test/resources/features/component.feature
+++ b/src/test/resources/features/component.feature
@@ -9,3 +9,21 @@ Feature: Component tests for TrainingController
     Given an existing training session ID
     When the request is sent to the delete endpoint
     Then the training session is deleted successfully
+
+  Scenario: Create a training session with invalid data
+    Given an invalid training request with missing or incorrect fields
+    When the request is sent to the create endpoint
+    Then the system returns a 400 Bad Request error
+    And an error message is displayed indicating which fields are invalid
+
+  Scenario: Create a training session for a non-existent trainer
+    Given a training request with a trainer ID that does not exist
+    When the request is sent to the create endpoint
+    Then the system returns a 404 Not Found error
+    And an error message is displayed indicating that the trainer was not found
+
+  Scenario: Delete a non-existent training session
+    Given a training session ID that does not exist
+    When the request is sent to the delete endpoint
+    Then the system returns a 404 Not Found error
+    And an error message is displayed indicating that the session was not found


### PR DESCRIPTION
This pull request introduces validation for training requests in the `TrainingManagementService` and adds corresponding component tests to ensure proper error handling. The changes include adding checks for missing required fields in the training request and updating the test scenarios to cover these cases.

Validation for training requests:

* [`src/main/java/com/uw/service/TrainingManagementService.java`](diffhunk://#diff-91487dff34fa7d14c6484264818fce68a078e38c001e1c41bfb675f831c3d68fR66-R69): Added validation to check for missing required fields (`trainingName`, `trainerUsername`, `traineeUsername`) in the `createTraining` method and return a `400 Bad Request` response if any are missing.

Component tests for error handling:

* [`src/test/java/com/uw/steps/ComponentTestSteps.java`](diffhunk://#diff-94b0bea3aa230dbbad8dbbc8cb5e23f012f863a04ec158c0df526e5b56410039R115-R169): Added new test steps to handle invalid training requests, including missing or incorrect fields, non-existent trainer IDs, and non-existent training session IDs.
* [`src/test/resources/features/component.feature`](diffhunk://#diff-97ac6e0771243c73c49e8931acf7ed1f7fb8fe0c266f7f1ad5aa99e2ffe1c6dbR12-R29): Added new test scenarios to validate the system's behavior when creating a training session with invalid data, creating a session for a non-existent trainer, and deleting a non-existent training session.